### PR TITLE
Fix BUG-003: polling interval resets on filter change

### DIFF
--- a/bugs/BUG-003/pipeline-state.json
+++ b/bugs/BUG-003/pipeline-state.json
@@ -1,0 +1,1 @@
+{"bug_id":"BUG-003","phase":"fix","branch":"fix/bug-003","fix_review_cycle":0,"module":"frontend","fixer_agent":"bug-fixer-frontend"}

--- a/bugs/BUG-003/report.md
+++ b/bugs/BUG-003/report.md
@@ -1,0 +1,158 @@
+# BUG-003: Frontend Polling Interval Resets on Filter Toggle
+
+| Field      | Value                                           |
+|------------|-------------------------------------------------|
+| ID         | BUG-003                                         |
+| Type       | Bug                                             |
+| Severity   | Medium                                          |
+| Priority   | P2                                              |
+| Status     | Open                                            |
+| Reporter   | bug-creator                                     |
+| Assignee   | bug-fixer-frontend                              |
+| Module     | frontend                                        |
+| Labels     | polling, tag-filter, useEffect, timer           |
+| Created    | 2026-03-15                                      |
+
+---
+
+## Summary
+
+The 5-second polling interval for metrics data resets to zero every time the user adds or removes a tag filter. This is caused by `activeTags` being listed as a dependency of the `useEffect` that owns the `setInterval` in `App.tsx`. Each filter change triggers React to tear down the old effect (clearing the interval) and mount a fresh one (starting the timer from zero), so the next scheduled poll is postponed by up to 5 seconds relative to when the user expected it.
+
+---
+
+## Steps to Reproduce
+
+1. Open the Metrics Dashboard frontend (`npm run dev`).
+2. Wait approximately 3–4 seconds after initial load (so the polling timer is roughly mid-cycle).
+3. Type a valid tag (e.g. `env:prod`) in the **Filter by tag** input and click **Add Filter**.
+4. Observe when the next API call to `/api/metrics` fires (e.g. via browser DevTools → Network tab).
+5. Remove the same tag chip by clicking the **×** button.
+6. Again observe when the next API call fires.
+
+---
+
+## Expected Behavior
+
+Adding or removing a tag filter should trigger an **immediate** one-time fetch with the new filter set, but the background polling timer should continue running on its existing schedule. The next periodic poll should fire at most `POLL_INTERVAL_MS` (5 000 ms) after the previous one — regardless of filter changes.
+
+---
+
+## Actual Behavior
+
+Every time a tag is added or removed, the polling interval resets from zero. Concretely:
+
+- If the user adds a tag at t = 4 s (1 s before the next scheduled poll), the next poll does not fire at t = 5 s — it fires at t = 9 s.
+- If the user toggles filters rapidly or repeatedly within any 5-second window, the periodic poll may be postponed indefinitely.
+- The dashboard therefore shows stale data for longer than users expect after any filtering interaction.
+
+---
+
+## Environment
+
+| Key              | Value                                |
+|------------------|--------------------------------------|
+| Component        | `frontend/src/App.tsx`               |
+| Framework        | React 18.3.1 (Vite 6, TypeScript 5) |
+| Test runner      | Vitest 2.1.8                         |
+| Node             | (project default — darwin/zsh)       |
+| Browser          | All (client-side timer issue)        |
+| Branch           | fix/bug-003                          |
+
+---
+
+## Severity
+
+**Medium** — Polling still occurs; data is not permanently lost. However, the user experience degrades measurably whenever tag filters are used interactively, and in pathological cases (rapid toggling) polling can be starved for multiple cycles.
+
+---
+
+## Module/Area
+
+**frontend** (`frontend/src/`)
+
+Primary file: `frontend/src/App.tsx` — `useEffect` at lines 39–46.
+
+---
+
+## Evidence
+
+### Root Cause — Source Code
+
+**File:** `frontend/src/App.tsx`, lines 39–46
+
+```tsx
+useEffect(() => {
+  const loadData = async () => {
+    await Promise.all([loadMetrics(), loadAlerts()])
+  }
+  loadData()                                    // immediate fetch ✓
+  const timer = setInterval(loadData, POLL_INTERVAL_MS)
+  return () => clearInterval(timer)             // cleanup on re-run
+}, [activeTags])                                // ← BUG: fires on every filter change
+```
+
+**Sequence of events when a tag is added/removed:**
+
+1. `activeTags` state changes → React schedules effect teardown + re-mount.
+2. Cleanup: `clearInterval(timer)` — the current polling timer is cancelled.
+3. Re-mount: `loadData()` fires immediately (correct), then `setInterval` restarts the 5 000 ms countdown **from zero**.
+4. Result: the next periodic poll is delayed by up to 5 000 ms relative to the previous one.
+
+### No Existing Test Covers This Regression
+
+`frontend/src/App.test.tsx` has a polling test (lines 69–87) that advances fake timers by 5 000 ms and verifies call counts, but it never changes `activeTags` mid-cycle. The test suite passes cleanly:
+
+```
+✓ src/App.test.tsx (13 tests) 206ms
+✓ src/api.test.ts (14 tests) 5ms
+✓ src/components/SparklineChart.test.tsx (4 tests) 14ms
+✓ src/components/MetricCard.test.tsx (7 tests) ...
+Test Files  4 passed (4)
+Tests  38 passed (38)
+```
+
+A new test that adds a tag at t = 4 000 ms and asserts the next poll fires by t = 10 000 ms (not t = 9 000 ms) would fail against the current implementation.
+
+### Proposed Reproduction Test (currently not in codebase)
+
+```tsx
+it('does not reset polling interval when activeTags changes', async () => {
+  vi.useFakeTimers()
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  render(<App />)
+
+  // Advance 4 seconds — one second before the first periodic poll
+  await vi.advanceTimersByTimeAsync(4000)
+  expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(1) // only initial
+
+  // Add a tag filter
+  const input = screen.getByPlaceholderText('Filter by tag (e.g. env:prod)')
+  await user.type(input, 'env:prod')
+  await user.click(screen.getByText('Add Filter'))
+
+  // Immediate re-fetch fires (due to activeTags change) — call count = 2
+  expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(2)
+
+  // With current bug: advancing 5 more seconds (total 9s) gets call count to 3
+  // EXPECTED (no reset): advancing only 1 more second (total 5s) should get 3
+  await vi.advanceTimersByTimeAsync(1000)
+  // This assertion FAILS with the current implementation:
+  expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(3)
+})
+```
+
+---
+
+## Root Cause Analysis
+
+`useEffect` with `[activeTags]` as dependency owns **both** the immediate data fetch and the recurring `setInterval`. Because React destroys and recreates the entire effect on each dependency change, the interval invariably restarts from zero. The fix is to decouple the two concerns: keep a single, stable `setInterval` on mount/unmount (empty dependency array `[]`), and trigger an additional one-time fetch whenever `activeTags` changes using a separate `useEffect([activeTags])` that does **not** touch the timer.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Changing `activeTags` (add or remove a filter) triggers an immediate `fetchMetrics` call with the new filter set.
+- [ ] The background polling timer is **not** reset when `activeTags` changes; the next periodic poll fires within `POLL_INTERVAL_MS` of the **previous** poll, not of the filter change.
+- [ ] A regression test is added to `App.test.tsx` that sets fake timers, advances to mid-cycle, changes a tag filter, advances past the original scheduled time, and asserts the poll fired on schedule.
+- [ ] All existing 38 tests continue to pass after the fix.

--- a/bugs/BUG-003/reviews/alpha.md
+++ b/bugs/BUG-003/reviews/alpha.md
@@ -1,0 +1,7 @@
+# Review: BUG-003
+
+## Reviewer: alpha
+
+## Verdict: APPROVE
+
+The fix correctly addresses the root cause by decoupling the stable polling interval from the filter state using a ref-based pattern. The implementation is minimal, the regression tests are well-designed and cover the core scenario plus tag removal. All 40 tests pass with real Vitest output. No regressions introduced.

--- a/bugs/BUG-003/reviews/beta.md
+++ b/bugs/BUG-003/reviews/beta.md
@@ -1,0 +1,7 @@
+# Review: BUG-003
+
+## Reviewer: beta
+
+## Verdict: APPROVE
+
+The fix correctly addresses the root cause by decoupling the stable polling interval from activeTags state via a useRef pattern and a separate useEffect for immediate filter-change fetches. Minimal implementation, idiomatic React, both add and remove scenarios covered by regression tests. All 40 tests pass. No regressions introduced.

--- a/bugs/BUG-003/routing.json
+++ b/bugs/BUG-003/routing.json
@@ -1,0 +1,1 @@
+{"module":"frontend","fixer_agent":"bug-fixer-frontend","confidence":"high"}

--- a/bugs/BUG-003/test-results.md
+++ b/bugs/BUG-003/test-results.md
@@ -1,0 +1,545 @@
+
+> aigile-frontend@0.1.0 test
+> vitest --run
+
+
+ RUN  v2.1.9 /Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend
+
+ ✓ src/api.test.ts (14 tests) 5ms
+ ✓ src/components/SparklineChart.test.tsx (4 tests) 14ms
+stderr | src/components/MetricCard.test.tsx > MetricCard > renders metric name and value
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+
+stderr | src/components/MetricCard.test.tsx > MetricCard > calls fetchMetricHistory on mount
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+
+stderr | src/App.test.tsx > App > renders the dashboard heading
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+stderr | src/components/MetricCard.test.tsx > MetricCard > renders delete button with correct aria label
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+
+stderr | src/components/MetricCard.test.tsx > MetricCard > renders metric tags
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+Warning: An update to MetricCard inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at MetricCard (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/components/MetricCard.tsx:9:23)
+
+ ✓ src/components/MetricCard.test.tsx (7 tests) 56ms
+stderr | src/App.test.tsx > App > Alert Integration Tests > polls both metrics and alerts synchronously
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+stderr | src/App.test.tsx > App > Alert Integration Tests > polls both metrics and alerts synchronously
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+stderr | src/App.test.tsx > App > Alert Integration Tests > handles alert fetch errors gracefully
+Failed to load alerts: Error: Alert service down
+    at /Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.test.tsx:91:9
+    at file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:146:14
+    at file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:533:11
+    at runWithTimeout (file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:39:7)
+    at runTest (file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:1056:17)
+    at runNextTicks (node:internal/process/task_queues:65:5)
+    at processImmediate (node:internal/timers:472:9)
+    at runSuite (file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runSuite (file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runSuite (file:///Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/node_modules/@vitest/runner/dist/index.js:1205:15)
+
+stderr | src/App.test.tsx > App > BUG-003: Polling interval must not reset on filter change > does not reset polling interval when activeTags changes
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+stderr | src/App.test.tsx > App > BUG-003: Polling interval must not reset on filter change > polling continues on schedule after removing a tag filter
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+stderr | src/App.test.tsx > App > BUG-003: Polling interval must not reset on filter change > polling continues on schedule after removing a tag filter
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+Warning: An update to App inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at App (/Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend/src/App.tsx:17:55)
+
+ ✓ src/App.test.tsx (15 tests) 221ms
+
+ Test Files  4 passed (4)
+      Tests  40 passed (40)
+   Start at  21:55:03
+   Duration  1.13s (transform 146ms, setup 175ms, collect 587ms, tests 296ms, environment 952ms, prepare 207ms)
+

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import App from './App'
@@ -183,6 +183,61 @@ describe('App', () => {
 
       expect(screen.queryByText('env:prod')).not.toBeInTheDocument()
       expect(vi.mocked(api.fetchMetrics)).toHaveBeenLastCalledWith([])
+    })
+  })
+
+  describe('BUG-003: Polling interval must not reset on filter change', () => {
+    it('does not reset polling interval when activeTags changes', async () => {
+      vi.useFakeTimers()
+      render(<App />)
+
+      // Initial fetch fires immediately
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(1)
+
+      // Advance 4 seconds — one second before the first periodic poll
+      await vi.advanceTimersByTimeAsync(4000)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(1) // still only initial
+
+      // Add a tag filter mid-cycle (use fireEvent to avoid userEvent timer issues)
+      const input = screen.getByPlaceholderText('Filter by tag (e.g. env:prod)')
+      fireEvent.change(input, { target: { value: 'env:prod' } })
+      fireEvent.click(screen.getByText('Add Filter'))
+
+      // Immediate re-fetch fires due to filter change — call count = 2
+      await vi.advanceTimersByTimeAsync(0)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(2)
+
+      // Advance 1 more second (total 5s from start) — the original poll should fire
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(3)
+    })
+
+    it('polling continues on schedule after removing a tag filter', async () => {
+      vi.useFakeTimers()
+      render(<App />)
+
+      // Initial fetch
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(1)
+
+      // Add a tag
+      const input = screen.getByPlaceholderText('Filter by tag (e.g. env:prod)')
+      fireEvent.change(input, { target: { value: 'env:prod' } })
+      fireEvent.click(screen.getByText('Add Filter'))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(2)
+
+      // Advance to first poll (5s)
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(3)
+
+      // Remove the tag at ~5s mark
+      fireEvent.click(screen.getByLabelText('Remove env:prod'))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(4)
+
+      // Next poll should fire at 10s (5s after previous poll), not 5s after removal
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(vi.mocked(api.fetchMetrics)).toHaveBeenCalledTimes(5)
     })
   })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { fetchAlerts, fetchMetrics, type AlertRule, type Metric } from './api'
 import { MetricCard } from './components/MetricCard'
 import { MetricForm } from './components/MetricForm'
@@ -13,10 +13,12 @@ export default function App() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [activeTags, setActiveTags] = useState<string[]>([])
+  const activeTagsRef = useRef(activeTags)
+  activeTagsRef.current = activeTags
 
   const loadMetrics = async () => {
     try {
-      const data = await fetchMetrics(activeTags)
+      const data = await fetchMetrics(activeTagsRef.current)
       setMetrics(data)
       setError(null)
     } catch (e) {
@@ -36,6 +38,7 @@ export default function App() {
     }
   }
 
+  // Stable polling interval — does NOT depend on activeTags
   useEffect(() => {
     const loadData = async () => {
       await Promise.all([loadMetrics(), loadAlerts()])
@@ -43,6 +46,16 @@ export default function App() {
     loadData()
     const timer = setInterval(loadData, POLL_INTERVAL_MS)
     return () => clearInterval(timer)
+  }, [])
+
+  // Immediate one-time fetch when filters change (skip initial mount)
+  const isInitialMount = useRef(true)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    loadMetrics()
   }, [activeTags])
 
   return (


### PR DESCRIPTION
## Bug Summary

**BUG-003** — The 5-second polling interval for metrics data reset to zero every time the user added or removed a tag filter. This caused the dashboard to show stale data for up to 5 extra seconds after any filtering interaction, and in pathological cases (rapid toggling) the periodic poll could be starved for multiple cycles.

Full bug report: `bugs/BUG-003/report.md`

## Root Cause

`useEffect` with `[activeTags]` as its dependency array owned **both** the immediate data fetch and the recurring `setInterval`. Because React destroys and recreates the entire effect on each dependency change, the interval invariably restarted from zero on every filter toggle.

```tsx
// BEFORE (buggy)
useEffect(() => {
  const loadData = async () => { await Promise.all([loadMetrics(), loadAlerts()]) }
  loadData()
  const timer = setInterval(loadData, POLL_INTERVAL_MS)
  return () => clearInterval(timer)
}, [activeTags])  // ← BUG: fires on every filter change, resetting the timer
```

## Fix Description

Decoupled the two concerns by splitting the single `useEffect` into two:

1. **Stable polling effect** (`[]` dependency): sets up and tears down the `setInterval` only on mount/unmount. Uses a `useRef` to always read the latest `activeTags` inside the interval callback without the effect depending on them.

2. **Filter-change effect** (`[activeTags]` dependency): triggers a single immediate `loadMetrics()` call when filters change. Skips the initial mount via an `isInitialMount` ref to avoid a duplicate fetch at startup.

```tsx
// AFTER (fixed)
const activeTagsRef = useRef(activeTags)
activeTagsRef.current = activeTags  // kept in sync on every render

// Stable polling interval — does NOT depend on activeTags
useEffect(() => {
  const loadData = async () => { await Promise.all([loadMetrics(), loadAlerts()]) }
  loadData()
  const timer = setInterval(loadData, POLL_INTERVAL_MS)
  return () => clearInterval(timer)
}, [])  // ← empty deps: timer is created once, never reset

// Immediate one-time fetch when filters change (skip initial mount)
const isInitialMount = useRef(true)
useEffect(() => {
  if (isInitialMount.current) { isInitialMount.current = false; return }
  loadMetrics()
}, [activeTags])
```

## Files Changed

- **`frontend/src/App.tsx`** — Split single `useEffect([activeTags])` into a stable polling effect `([])` + a filter-change effect `([activeTags])`; added `activeTagsRef` to give the stable interval access to current tags without re-registering.
- **`frontend/src/App.test.tsx`** — Added `describe('BUG-003: Polling interval must not reset on filter change')` with 2 regression tests covering add-tag mid-cycle and remove-tag mid-cycle scenarios.
- **`bugs/BUG-003/report.md`** — Bug report (new file).
- **`bugs/BUG-003/test-results.md`** — Test output evidence (new file).
- **`bugs/BUG-003/pipeline-state.json`** — Pipeline tracking metadata.
- **`bugs/BUG-003/routing.json`** — Module routing metadata.

## Test Evidence

```
> aigile-frontend@0.1.0 test
> vitest --run

 RUN  v2.1.9 /Users/vobbilis/go/src/github.com/vobbilis/codegen/metrics-dashboard/frontend

 ✓ src/api.test.ts (14 tests) 5ms
 ✓ src/components/SparklineChart.test.tsx (4 tests) 14ms
 ✓ src/components/MetricCard.test.tsx (7 tests) 56ms
 ✓ src/App.test.tsx (15 tests) 221ms

 Test Files  4 passed (4)
      Tests  40 passed (40)
   Start at  21:55:03
   Duration  1.13s (transform 146ms, setup 175ms, collect 587ms, tests 296ms, environment 952ms, prepare 207ms)
```

**New regression tests added (both passing):**
- `BUG-003: Polling interval must not reset on filter change > does not reset polling interval when activeTags changes`
- `BUG-003: Polling interval must not reset on filter change > polling continues on schedule after removing a tag filter`

All 40 tests pass (up from 38 pre-fix; +2 BUG-003 regression tests).